### PR TITLE
fix: proposer boost reorg e2e test

### DIFF
--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -7,7 +7,7 @@ import {
   ForkChoiceStore,
   ExecutionStatus,
   JustifiedBalancesGetter,
-  ForkChoiceOpts,
+  ForkChoiceOpts as RawForkChoiceOpts,
 } from "@lodestar/fork-choice";
 import {
   CachedBeaconStateAllForks,
@@ -22,7 +22,10 @@ import {ChainEventEmitter} from "../emitter.js";
 import {ChainEvent} from "../emitter.js";
 import {GENESIS_SLOT} from "../../constants/index.js";
 
-export type {ForkChoiceOpts};
+export type ForkChoiceOpts = RawForkChoiceOpts & {
+  // for testing only
+  forkchoiceConstructor?: typeof ForkChoice;
+};
 
 /**
  * Fork Choice extended with a ChainEventEmitter
@@ -49,7 +52,11 @@ export function initializeForkChoice(
 
   const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(state);
 
-  return new ForkChoice(
+  // forkchoiceConstructor is only used for some test cases
+  // production code use ForkChoice constructor directly
+  const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
+
+  return new forkchoiceConstructor(
     config,
 
     new ForkChoiceStore(

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -28,7 +28,6 @@ import {ChainForkConfig} from "@lodestar/config";
 import {ForkSeq, ForkExecution, isForkExecution} from "@lodestar/params";
 import {toHex, sleep, Logger} from "@lodestar/utils";
 
-import {ProtoBlock} from "@lodestar/fork-choice";
 import type {BeaconChain} from "../chain.js";
 import {PayloadId, IExecutionEngine, IExecutionBuilder, PayloadAttributes} from "../../execution/index.js";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
@@ -65,8 +64,8 @@ export type BlockAttributes = {
   randaoReveal: BLSSignature;
   graffiti: Bytes32;
   slot: Slot;
+  parentBlockRoot: Root;
   feeRecipient?: string;
-  proposerHead?: ProtoBlock;
 };
 
 export enum BlockType {
@@ -97,7 +96,6 @@ export async function produceBlockBody<T extends BlockType>(
   currentState: CachedBeaconStateAllForks,
   blockAttr: BlockAttributes & {
     parentSlot: Slot;
-    parentBlockRoot: Root;
     proposerIndex: ValidatorIndex;
     proposerPubKey: BLSPubkey;
     commonBlockBody?: CommonBlockBody;
@@ -582,7 +580,6 @@ export async function produceCommonBlockBody<T extends BlockType>(
     parentBlockRoot,
   }: BlockAttributes & {
     parentSlot: Slot;
-    parentBlockRoot: Root;
   }
 ): Promise<CommonBlockBody> {
   const stepsMetrics =

--- a/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
+++ b/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
@@ -1,0 +1,133 @@
+import {describe, it, afterEach, expect} from "vitest";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {TimestampFormatCode} from "@lodestar/logger";
+import {ChainConfig} from "@lodestar/config";
+import {RootHex, Slot} from "@lodestar/types";
+import {routes} from "@lodestar/api";
+import {toHexString} from "@lodestar/utils";
+import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+import {TimelinessForkChoice} from "../../mocks/fork-choice/timeliness.js";
+import {getAndInitDevValidators} from "../../utils/node/validator.js";
+import {waitForEvent} from "../../utils/events/resolver.js";
+import {ReorgEventData} from "../../../src/chain/emitter.js";
+
+describe(
+  "proposer boost reorg",
+  function () {
+    const validatorCount = 8;
+    const testParams: Pick<ChainConfig, "SECONDS_PER_SLOT" | "REORG_PARENT_WEIGHT_THRESHOLD" | "PROPOSER_SCORE_BOOST"> =
+      {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        SECONDS_PER_SLOT: 2,
+        // need this to make block `reorgSlot - 1` strong enough
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        REORG_PARENT_WEIGHT_THRESHOLD: 80,
+        // need this to make block `reorgSlot + 1` to become the head
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        PROPOSER_SCORE_BOOST: 120,
+      };
+
+    const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+    afterEach(async () => {
+      while (afterEachCallbacks.length > 0) {
+        const callback = afterEachCallbacks.pop();
+        if (callback) await callback();
+      }
+    });
+
+    const reorgSlot = 10;
+    const proposerBoostReorgEnabled = true;
+    /**
+     *                reorgSlot
+     *              /
+     * reorgSlot - 1 ------------ reorgSlot + 1
+     */
+    it(`should reorg a late block at slot ${reorgSlot}`, async () => {
+      // the node needs time to transpile/initialize bls worker threads
+      const genesisSlotsDelay = 7;
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
+      const testLoggerOpts: TestLoggerOpts = {
+        level: LogLevel.debug,
+        timestampFormat: {
+          format: TimestampFormatCode.EpochSlot,
+          genesisTime,
+          slotsPerEpoch: SLOTS_PER_EPOCH,
+          secondsPerSlot: testParams.SECONDS_PER_SLOT,
+        },
+      };
+      const logger = testLogger("BeaconNode", testLoggerOpts);
+      const bn = await getDevBeaconNode({
+        params: testParams,
+        options: {
+          sync: {isSingleNode: true},
+          network: {allowPublishToZeroPeers: true, mdns: true, useWorker: false},
+          // run the first bn with ReorgedForkChoice, no nHistoricalStates flag so it does not have to reload
+          chain: {
+            blsVerifyAllMainThread: true,
+            forkchoiceConstructor: TimelinessForkChoice,
+            proposerBoostEnabled: true,
+            proposerBoostReorgEnabled,
+          },
+        },
+        validatorCount,
+        genesisTime,
+        logger,
+      });
+
+      (bn.chain.forkChoice as TimelinessForkChoice).lateSlot = reorgSlot;
+      afterEachCallbacks.push(async () => bn.close());
+      const {validators} = await getAndInitDevValidators({
+        node: bn,
+        logPrefix: "vc-0",
+        validatorsPerClient: validatorCount,
+        validatorClientCount: 1,
+        startIndex: 0,
+        useRestApi: false,
+        testLoggerOpts,
+      });
+      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close())));
+
+      const commonAncestor = await waitForEvent<{slot: Slot; block: RootHex}>(
+        bn.chain.emitter,
+        routes.events.EventType.head,
+        240000,
+        ({slot}) => slot === reorgSlot - 1
+      );
+      //               reorgSlot
+      //                /
+      // commonAncestor ------------ newBlock
+      const commonAncestorRoot = commonAncestor.block;
+      const reorgBlockEventData = await waitForEvent<{slot: Slot; block: RootHex}>(
+        bn.chain.emitter,
+        routes.events.EventType.head,
+        240000,
+        ({slot}) => slot === reorgSlot
+      );
+      const reorgBlockRoot = reorgBlockEventData.block;
+      const [newBlockEventData, reorgEventData] = await Promise.all([
+        waitForEvent<{slot: Slot; block: RootHex}>(
+          bn.chain.emitter,
+          routes.events.EventType.block,
+          240000,
+          ({slot}) => slot === reorgSlot + 1
+        ),
+        waitForEvent<ReorgEventData>(bn.chain.emitter, routes.events.EventType.chainReorg, 240000),
+      ]);
+      expect(reorgEventData.slot).toEqual(reorgSlot + 1);
+      const newBlock = await bn.chain.getBlockByRoot(newBlockEventData.block);
+      if (newBlock == null) {
+        throw Error(`Block ${reorgSlot + 1} not found`);
+      }
+      expect(reorgEventData.oldHeadBlock).toEqual(reorgBlockRoot);
+      expect(reorgEventData.newHeadBlock).toEqual(newBlockEventData.block);
+      expect(reorgEventData.depth).toEqual(2);
+      expect(toHexString(newBlock?.block.message.parentRoot)).toEqual(commonAncestorRoot);
+      logger.info("New block", {
+        slot: newBlock.block.message.slot,
+        parentRoot: toHexString(newBlock.block.message.parentRoot),
+      });
+    });
+  },
+  {timeout: 60000}
+);

--- a/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
+++ b/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
@@ -46,6 +46,9 @@ describe(
      * Note that in additional of being not timely, there are other criterion that
      * the block needs to satisfied before being re-orged out. This test assumes
      * other criterion are satisfied except timeliness.
+     * Note that in additional of being not timely, there are other criterion that 
+     * the block needs to satisfy before being re-orged out. This test assumes 
+     * other criterion are already satisfied
      */
     it(`should reorg a late block at slot ${reorgSlot}`, async () => {
       // the node needs time to transpile/initialize bls worker threads

--- a/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
+++ b/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
@@ -42,6 +42,10 @@ describe(
      *                reorgSlot
      *              /
      * reorgSlot - 1 ------------ reorgSlot + 1
+     *
+     * Note that in additional of being not timely, there are other criterion that
+     * the block needs to satisfied before being re-orged out. This test assumes
+     * other criterion are satisfied except timeliness.
      */
     it(`should reorg a late block at slot ${reorgSlot}`, async () => {
       // the node needs time to transpile/initialize bls worker threads

--- a/packages/beacon-node/test/mocks/fork-choice/timeliness.ts
+++ b/packages/beacon-node/test/mocks/fork-choice/timeliness.ts
@@ -1,0 +1,24 @@
+import {ForkChoice} from "@lodestar/fork-choice";
+import {Slot, allForks} from "@lodestar/types";
+
+/**
+ * A specific forkchoice implementation to mark some blocks as timely or not.
+ */
+export class TimelinessForkChoice extends ForkChoice {
+  /**
+   * These need to be in the constructor, however we want to keep the constructor signature the same.
+   * So they are set after construction in the test instead.
+   */
+  lateSlot: Slot | undefined;
+
+  /**
+   * This is to mark the `lateSlot` as not timely.
+   */
+  protected isBlockTimely(block: allForks.BeaconBlock, blockDelaySec: number): boolean {
+    if (block.slot === this.lateSlot) {
+      return false;
+    }
+
+    return super.isBlockTimely(block, blockDelaySec);
+  }
+}

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -75,9 +75,9 @@ describe("produceBlockBody", () => {
       await produceBlockBody.call(chain, BlockType.Full, state, {
         parentSlot: slot,
         slot: slot + 1,
+        parentBlockRoot: fromHexString(head.blockRoot),
         graffiti: Buffer.alloc(32),
         randaoReveal: Buffer.alloc(96),
-        parentBlockRoot: fromHexString(head.blockRoot),
         proposerIndex,
         proposerPubKey,
       });

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
@@ -1,4 +1,4 @@
-import {fromHexString} from "@chainsafe/ssz";
+import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";
 import {ssz} from "@lodestar/types";
 import {ProtoBlock} from "@lodestar/fork-choice";
@@ -43,9 +43,12 @@ describe("api/validator - produceBlockV2", function () {
     // Set the node's state to way back from current slot
     const slot = 100000;
     const randaoReveal = fullBlock.body.randaoReveal;
+    const parentBlockRoot = fullBlock.parentRoot;
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xcccccccccccccccccccccccccccccccccccccccc";
 
+    // mock whatever value as we also mock produceBlock below
+    modules.chain["getProposerHead"].mockReturnValue(generateProtoBlock({blockRoot: toHexString(parentBlockRoot)}));
     modules.chain.produceBlock.mockResolvedValue({
       block: fullBlock,
       executionPayloadValue,
@@ -58,6 +61,7 @@ describe("api/validator - produceBlockV2", function () {
       randaoReveal,
       graffiti: toGraffitiBuffer(graffiti),
       slot,
+      parentBlockRoot,
       feeRecipient,
     });
 
@@ -68,6 +72,7 @@ describe("api/validator - produceBlockV2", function () {
       randaoReveal,
       graffiti: toGraffitiBuffer(graffiti),
       slot,
+      parentBlockRoot,
       feeRecipient: undefined,
     });
   });
@@ -81,7 +86,7 @@ describe("api/validator - produceBlockV2", function () {
     const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
 
     const headSlot = 0;
-    modules.forkChoice.getHead.mockReturnValue(generateProtoBlock({slot: headSlot}));
+    modules.chain["getProposerHead"].mockReturnValue(generateProtoBlock({slot: headSlot}));
 
     modules.chain["opPool"].getSlashingsAndExits.mockReturnValue([[], [], [], []]);
     modules.chain["aggregatedAttestationPool"].getAttestationsForBlock.mockReturnValue([]);

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -1,8 +1,10 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";
+import {toHexString} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {ProtoBlock} from "@lodestar/fork-choice";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
 import {SyncState} from "../../../../../src/sync/interface.js";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
@@ -82,6 +84,8 @@ describe("api/validator - produceBlockV3", function () {
 
         vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(currentSlot);
         vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
+
+        modules.chain.getProposerHead.mockReturnValue({blockRoot: toHexString(fullBlock.parentRoot)} as ProtoBlock);
 
         if (enginePayloadValue !== null) {
           const commonBlockBody: CommonBlockBody = {

--- a/packages/beacon-node/test/utils/logger.ts
+++ b/packages/beacon-node/test/utils/logger.ts
@@ -21,6 +21,6 @@ export const testLogger = (module?: string, opts?: TestLoggerOpts): LoggerNode =
     opts.module = module;
   }
   const level = getEnvLogLevel();
-  opts.level = level ?? LogLevel.info;
+  opts.level = level ?? opts.level ?? LogLevel.info;
   return getNodeLogger(opts);
 };

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -503,8 +503,7 @@ export class ForkChoice implements IForkChoice {
 
     // Assign proposer score boost if the block is timely
     // before attesting interval = before 1st interval
-    const isBeforeAttestingInterval = blockDelaySec < this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
-    const isTimely = this.fcStore.currentSlot === slot && isBeforeAttestingInterval;
+    const isTimely = this.isBlockTimely(block, blockDelaySec);
     if (
       this.opts?.proposerBoostEnabled &&
       isTimely &&
@@ -1048,6 +1047,15 @@ export class ForkChoice implements IForkChoice {
     }
 
     throw Error(`Not found dependent root for block slot ${block.slot}, epoch difference ${epochDifference}`);
+  }
+
+  /**
+   * Return true if the block is timely for the current slot.
+   * Child class can overwrite this for testing purpose.
+   */
+  protected isBlockTimely(block: allForks.BeaconBlock, blockDelaySec: number): boolean {
+    const isBeforeAttestingInterval = blockDelaySec < this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
+    return this.fcStore.currentSlot === block.slot && isBeforeAttestingInterval;
   }
 
   private getPreMergeExecStatus(executionStatus: MaybeValidExecutionStatus): ExecutionStatus.PreMerge {


### PR DESCRIPTION
**Motivation**

- make sure proposer boost reorg work through e2e test

**Description**

- New method `isBlockTimely` in forkchoice to allow child forkchoice to mark a block as late
- Put `parentBlockRoot` to `BlockAttributes`, make it as `chain.getProposerHead()` and pass it from api, should not use `getHead()` during producing block anymore
- e2e test

link to the main PR: https://github.com/ChainSafe/lodestar/pull/6298
